### PR TITLE
类内部数组(emptyStringArray)元素的可变性不应暴露给外部

### DIFF
--- a/dao-gen-core/src/main/java/com/ctrip/platform/dal/daogen/utils/Configuration.java
+++ b/dao-gen-core/src/main/java/com/ctrip/platform/dal/daogen/utils/Configuration.java
@@ -147,11 +147,11 @@ public class Configuration {
         }
     }
 
-    public final static String[] emptyStringArray = {};
+    private final static String[] emptyStringArray = {};
 
     public static String[] getTrimmedStrings(String str) {
         if (null == str || "".equals(str.trim()))
-            return emptyStringArray;
+            return emptyStringArray.clone();
 
         return str.trim().split("\\s*,\\s*");
     }


### PR DESCRIPTION
类内部数组(emptyStringArray)元素的可变性不应暴露给外部，防止客户端程序无意或者有意改变了数据的内容，其他客户端代码可能读取到改变之后的数据，进而导致逻辑错误。